### PR TITLE
Add parsing for numbers and optimize the code.

### DIFF
--- a/src/lexer/lexer.rs
+++ b/src/lexer/lexer.rs
@@ -18,15 +18,15 @@ enum State {
     CdCommandState,
 
     // number
-    Num,
+    NumState,
 
     // Parameter: if the first char is '-' then  transform state to Param.
-    Param,
+    ParamState,
     // short parameter (-short)
-    ShortParam,
+    ShortParamState,
     // long parameter (--long)
-    LongParam1,
-    LongParam,
+    LongParamState1,
+    LongParamState,
 
     // Single Symbols
     PipeState,        // |
@@ -109,28 +109,28 @@ impl Lexer {
                     self.store_token_and_trans_state(index);
                 }
 
-                State::Num => {}
+                State::NumState => {}
 
                 // =============== parameter ===============
-                State::Param => {
+                State::ParamState => {
                     if c.is_alphabetic() {
-                        *(self.cur_state.borrow_mut()) = State::ShortParam;
+                        *(self.cur_state.borrow_mut()) = State::ShortParamState;
                     } else if *c == '-' {
-                        *(self.cur_state.borrow_mut()) = State::LongParam1;
+                        *(self.cur_state.borrow_mut()) = State::LongParamState1;
                     }
                 }
 
-                State::ShortParam => {
+                State::ShortParamState => {
                     self.store_token_and_trans_state(index);
                 }
 
-                State::LongParam1 => {
+                State::LongParamState1 => {
                     if c.is_alphabetic() {
-                        *(self.cur_state.borrow_mut()) = State::LongParam;
+                        *(self.cur_state.borrow_mut()) = State::LongParamState;
                     }
                 }
 
-                State::LongParam => {
+                State::LongParamState => {
                     if !c.is_alphanumeric() {
                         self.store_token_and_trans_state(index);
                     }
@@ -185,8 +185,8 @@ impl Lexer {
             let token_type = match *state {
                 State::LsCommandState => TokenType::Ls,
                 State::CdCommandState => TokenType::Cd,
-                State::ShortParam => TokenType::ShortParam,
-                State::LongParam => TokenType::LongParam,
+                State::ShortParamState => TokenType::ShortParam,
+                State::LongParamState => TokenType::LongParam,
                 State::PipeState => TokenType::Pipe,
                 State::CommaState => TokenType::Comma,
                 State::SemicolonState => TokenType::Semicolon,
@@ -256,8 +256,8 @@ impl Lexer {
         match c {
             'l' => State::LsCommandState1,
             'c' => State::CdCommandState1,
-            '0'..='9' => State::Num,
-            '-' => State::Param,
+            '0'..='9' => State::NumState,
+            '-' => State::ParamState,
             '|' => State::PipeState,
             ',' => State::CommaState,
             ';' => State::SemicolonState,

--- a/tests/lexer_test.rs
+++ b/tests/lexer_test.rs
@@ -148,4 +148,60 @@ mod test {
         assert_eq!(assignment_token.token_type, l.tokens.borrow()[7].token_type);
         assert_eq!(assignment_token.literal, l.tokens.borrow()[7].literal);
     }
+
+    #[test]
+    fn test_num_tokens() {
+        let l = Lexer::new(
+            "123 456 123_456 12_3456 1_000_000 1_0000_0000_0000".to_string(),
+        );
+
+        // println!("{:#?}", l);
+
+        let token_123 = Token::new(
+            TokenType::Num,
+            "123".to_string(),
+        );
+        assert_eq!(token_123.token_type, l.tokens.borrow()[0].token_type);
+        assert_eq!(token_123.literal, l.tokens.borrow()[0].literal);
+
+
+        let token_456 = Token::new(
+            TokenType::Num,
+            "456".to_string(),
+        );
+        assert_eq!(token_456.token_type, l.tokens.borrow()[1].token_type);
+        assert_eq!(token_456.literal, l.tokens.borrow()[1].literal);
+
+
+        let token_123_456 = Token::new(
+            TokenType::Num,
+            "123_456".to_string(),
+        );
+        assert_eq!(token_123_456.token_type, l.tokens.borrow()[2].token_type);
+        assert_eq!(token_123_456.literal, l.tokens.borrow()[2].literal);
+
+
+        let token_12_3456 = Token::new(
+            TokenType::Num,
+            "12_3456".to_string(),
+        );
+        assert_eq!(token_12_3456.token_type, l.tokens.borrow()[3].token_type);
+        assert_eq!(token_12_3456.literal, l.tokens.borrow()[3].literal);
+
+
+        let token_1_000_000 = Token::new(
+            TokenType::Num,
+            "1_000_000".to_string(),
+        );
+        assert_eq!(token_1_000_000.token_type, l.tokens.borrow()[4].token_type);
+        assert_eq!(token_1_000_000.literal, l.tokens.borrow()[4].literal);
+
+        
+        let token_1_0000_0000_0000 = Token::new(
+            TokenType::Num,
+            "1_0000_0000_0000".to_string(),
+        );
+        assert_eq!(token_1_0000_0000_0000.token_type, l.tokens.borrow()[5].token_type);
+        assert_eq!(token_1_0000_0000_0000.literal, l.tokens.borrow()[5].literal);
+    }
 }


### PR DESCRIPTION
1. Add parsing for numbers, for eample: 123 456 123_456 12_3456 1_000_000 1_0000_0000_0000. You can use underline among the number string.
2. Optimized the code that uses the "==" symbol to determine if characters are equal by replacing it with the official library's (*char).eq() method.