### PR TITLE
Delete iterator for lexer.

### DIFF
--- a/src/lexer/lexer.rs
+++ b/src/lexer/lexer.rs
@@ -19,39 +19,10 @@ pub struct Lexer {
     // This is a key field to show the state about lexer at now.
     // It's used to define the type of the token currently.
     cur_state: RefCell<State>,
-}
 
-// Lexer iterator
-pub struct LexerIter<'a> {
-    lexer: &'a Lexer,
+    // Current index of token vector.
+    // This field is used to iterate the tokens.
     position: usize,
-}
-
-impl<'a> Lexer {
-    pub fn iter(&'a self) -> LexerIter<'a> {
-        LexerIter {
-            lexer: self,
-            position: 0,
-        }
-    }
-}
-
-// Implement Iterator trait for LexerIter
-impl<'a> Iterator for LexerIter<'a> {
-    type Item = Token;
-
-    // The next() method returns an Option<Token> because it returns None when it reaches the end of the token list.
-    // Parser will use this method to get tokens.
-    fn next(&mut self) -> Option<Self::Item> {
-        if self.position >= self.lexer.tokens.borrow().len() {
-            return None;
-        }
-
-        let token = self.lexer.tokens.borrow()[self.position].clone();
-        self.position += 1;
-        
-        Some(token)
-    }
 }
 
 impl Lexer {
@@ -61,11 +32,37 @@ impl Lexer {
             start_index: RefCell::new(0),
             tokens: RefCell::new(Vec::new()),
             cur_state: RefCell::new(State::Start),
+            position: 0,
         };
 
         l.analyze_command();
 
         l
+    }
+
+    // Iterate the tokens.
+    pub fn next_token(&mut self) -> Option<Token> {
+        let tokens = self.tokens.borrow();
+        if self.position >= tokens.len() {
+            return None;
+        }
+
+        let token = tokens[self.position].clone();
+        self.position += 1;
+
+        Some(token)
+    }
+
+    // Peek the next token.
+    pub fn peek_token(&self) -> Option<Token> {
+        let tokens = self.tokens.borrow();
+        if self.position >= tokens.len() {
+            return None;
+        }
+
+        let token = tokens[self.position].clone();
+
+        Some(token)
     }
 
     // Analyze the command and generate tokens.

--- a/tests/lexer_test.rs
+++ b/tests/lexer_test.rs
@@ -10,33 +10,34 @@ mod test {
 
     #[test]
     fn test_lexer_iter() {
-        let _l = Lexer::new(
+        let mut _l = Lexer::new(
             "a abc _abc _123 Abc_de 123_abc 123_A_b   ,| ;  >   < .:= /* & && &&& ||".to_string(),
         );
 
-        // for (index, token) in _l.iter().enumerate() {
-        //     println!("{}: {:#?}", index, token);
+        // while let Some(token) = l.next_token() {
+        //     println!("{:?}", token);
         // }
     }
 
     #[test]
     fn test_lexer_one_param() {
-        let l = Lexer::new("ls -t".to_string());
+        let mut l = Lexer::new("ls -t".to_string());
 
         let tokens = vec![
             Token::new(TokenType::Ls, "ls".to_string()),
             Token::new(TokenType::ShortParam, "-t".to_string()),
         ];
 
-        for (index, token) in l.iter().enumerate() {
-            assert_eq!(*tokens[index].token_type(), *token.token_type());
-            assert_eq!(tokens[index].literal(), token.literal());
+        for token in tokens.iter() {
+            let next_token = l.next_token().unwrap();
+            assert_eq!(*token.token_type(), *next_token.token_type());
+            assert_eq!(token.literal(), next_token.literal());
         }
     }
 
     #[test]
     fn test_lexer_more_short_param() {
-        let l = Lexer::new("ls -l -h -t".to_string());
+        let mut l = Lexer::new("ls -l -h -t".to_string());
 
         let tokens = vec![
             Token::new(TokenType::Ls, "ls".to_string()),
@@ -45,27 +46,29 @@ mod test {
             Token::new(TokenType::ShortParam, "-t".to_string()),
         ];
 
-        for (index, token) in l.iter().enumerate() {
-            assert_eq!(*tokens[index].token_type(), *token.token_type());
-            assert_eq!(tokens[index].literal(), token.literal());
+        for token in tokens.iter() {
+            let next_token = l.next_token().unwrap();
+            assert_eq!(*token.token_type(), *next_token.token_type());
+            assert_eq!(token.literal(), next_token.literal());
         }
     }
 
     #[test]
     fn test_cd_command() {
-        let l = Lexer::new("cd".to_string());
+        let mut l = Lexer::new("cd".to_string());
 
         let tokens = vec![Token::new(TokenType::Cd, "cd".to_string())];
 
-        for (index, token) in l.iter().enumerate() {
-            assert_eq!(*tokens[index].token_type(), *token.token_type());
-            assert_eq!(tokens[index].literal(), token.literal());
+        for token in tokens.iter() {
+            let next_token = l.next_token().unwrap();
+            assert_eq!(*token.token_type(), *next_token.token_type());
+            assert_eq!(token.literal(), next_token.literal());
         }
     }
 
     #[test]
     fn test_parse_long_param() {
-        let l = Lexer::new("  ls -l --lp  ".to_string());
+        let mut l = Lexer::new("  ls -l --lp  ".to_string());
 
         let tokens = vec![
             Token::new(TokenType::Ls, "ls".to_string()),
@@ -73,15 +76,16 @@ mod test {
             Token::new(TokenType::LongParam, "--lp".to_string()),
         ];
 
-        for (index, token) in l.iter().enumerate() {
-            assert_eq!(*tokens[index].token_type(), *token.token_type());
-            assert_eq!(tokens[index].literal(), token.literal());
+        for token in tokens.iter() {
+            let next_token = l.next_token().unwrap();
+            assert_eq!(*token.token_type(), *next_token.token_type());
+            assert_eq!(token.literal(), next_token.literal());
         }
     }
 
     #[test]
     fn test_single_symbols() {
-        let l = Lexer::new("   ,| ;  >   < .:= /* & && &&& ||".to_string());
+        let mut l = Lexer::new("   ,| ;  >   < .:= /* & && &&& ||".to_string());
 
         let tokens = vec![
             Token::new(TokenType::Comma, ",".to_string()),
@@ -101,15 +105,16 @@ mod test {
             Token::new(TokenType::Or, "||".to_string()),
         ];
 
-        for (index, token) in l.iter().enumerate() {
-            assert_eq!(*tokens[index].token_type(), *token.token_type());
-            assert_eq!(tokens[index].literal(), token.literal());
+        for token in tokens.iter() {
+            let next_token = l.next_token().unwrap();
+            assert_eq!(*token.token_type(), *next_token.token_type());
+            assert_eq!(token.literal(), next_token.literal());
         }
     }
 
     #[test]
     fn test_num_tokens() {
-        let l = Lexer::new("123 456 123_456 12_3456 1_000_000 1_0000_0000_0000".to_string());
+        let mut l = Lexer::new("123 456 123_456 12_3456 1_000_000 1_0000_0000_0000".to_string());
 
         let tokens = vec![
             Token::new(TokenType::Num, "123".to_string()),
@@ -120,15 +125,16 @@ mod test {
             Token::new(TokenType::Num, "1_0000_0000_0000".to_string()),
         ];
 
-        for (index, token) in l.iter().enumerate() {
-            assert_eq!(*tokens[index].token_type(), *token.token_type());
-            assert_eq!(tokens[index].literal(), token.literal());
+        for token in tokens.iter() {
+            let next_token = l.next_token().unwrap();
+            assert_eq!(*token.token_type(), *next_token.token_type());
+            assert_eq!(token.literal(), next_token.literal());
         }
     }
 
     #[test]
     fn test_literal_tokens() {
-        let l = Lexer::new("a abc _abc _123 Abc_de 123_abc 123_A_b".to_string());
+        let mut l = Lexer::new("a abc _abc _123 Abc_de 123_abc 123_A_b".to_string());
 
         let tokens = vec![
             Token::new(TokenType::Literal, "a".to_string()),
@@ -140,9 +146,10 @@ mod test {
             Token::new(TokenType::Literal, "123_A_b".to_string()),
         ];
 
-        for (index, token) in l.iter().enumerate() {
-            assert_eq!(*tokens[index].token_type(), *token.token_type());
-            assert_eq!(tokens[index].literal(), token.literal());
+        for token in tokens.iter() {
+            let next_token = l.next_token().unwrap();
+            assert_eq!(*token.token_type(), *next_token.token_type());
+            assert_eq!(token.literal(), next_token.literal());
         }
     }
 }


### PR DESCRIPTION
Using an iterator would limit my freedom to check tokens in the parser, so I am removing the iterator implementation from the lexer.