### PR TITLE
Redesign the interface names

### DIFF
--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use crate::token::token::Token;
 
-use super::CommandAstNode;
+use super::{ExtCommandAstNode, Command};
 
 #[derive(Debug)]
 pub struct LsCommand {
@@ -21,11 +21,13 @@ impl LsCommand {
     }
 }
 
-impl CommandAstNode for LsCommand {
+impl Command for LsCommand {
     fn name(&self) -> &str {
         self.token.literal()
     }
+}
 
+impl ExtCommandAstNode for LsCommand {
     fn set_options(&mut self, options: Vec<(String, String)>) {
         for (option, value) in options {
             self.option.insert(option, value);
@@ -37,7 +39,7 @@ impl CommandAstNode for LsCommand {
     }
 
     fn set_values(&mut self, values: Vec<String>) {
-        self.value = values;   
+        self.value = values;
     }
 }
 
@@ -58,11 +60,13 @@ impl CdCommand {
     }
 }
 
-impl CommandAstNode for CdCommand {
+impl Command for CdCommand {
     fn name(&self) -> &str {
         self.token.literal()
     }
-    
+}
+
+impl ExtCommandAstNode for CdCommand {
     fn set_options(&mut self, options: Vec<(String, String)>) {
         for (option, value) in options {
             self.option.insert(option, value);
@@ -72,8 +76,8 @@ impl CommandAstNode for CdCommand {
     fn get_option(&self, option: &str) -> Option<&str> {
         self.option.get(option).map(|s| s.as_str())
     }
-    
+
     fn set_values(&mut self, values: Vec<String>) {
-        self.value = values;   
+        self.value = values;
     }
 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1,12 +1,14 @@
 pub mod ast;
 pub mod parser;
 
-// The CommandAstNode trait is used to define the common interface for the command AST node.
-pub trait CommandAstNode: std::fmt::Debug {
-
-    // Return the command name.
+// This trait is used to define the command,
+pub trait Command: std::fmt::Debug {
+    // Get the command name.
     fn name(&self) -> &str;
+}
 
+// The CommandAstNode trait is used to define the common interface for the command AST node.
+pub trait ExtCommandAstNode: std::fmt::Debug + Command {
     // Set the command option.
     fn set_options(&mut self, options: Vec<(String, String)>);
 
@@ -15,4 +17,12 @@ pub trait CommandAstNode: std::fmt::Debug {
 
     // Add the command value.
     fn set_values(&mut self, values: Vec<String>);
+}
+
+pub trait ChainCommandAstNode: std::fmt::Debug + Command {
+    /// Set the data source from [`ExtCommandAstNode`].
+    fn set_source(&mut self, values: dyn ExtCommandAstNode);
+
+    // Set the data destination to [`CommandAstNode`].
+    fn set_destination(&mut self, values: dyn ExtCommandAstNode);
 }

--- a/tests/parser_test.rs
+++ b/tests/parser_test.rs
@@ -1,13 +1,13 @@
 #[cfg(test)]
 mod parser_test {
     use ru_shell::parser::ast::LsCommand;
-    use ru_shell::parser::CommandAstNode;
+    use ru_shell::parser::ExtCommandAstNode;
     use ru_shell::parser::parser::Parser;
     use ru_shell::token::token::{Token, TokenType};
 
     #[test]
     fn test_show_command() {
-        let mut command_ast: Vec<Box<dyn CommandAstNode>> = Vec::new();
+        let mut command_ast: Vec<Box<dyn ExtCommandAstNode>> = Vec::new();
 
         let mut ls_command = LsCommand::new(Token::new(TokenType::Ls, "ls".to_string()));
         ls_command.set_options(vec![


### PR DESCRIPTION
Separating the execution of commands and chain commands, to facilitate separate design of executors in the future.