### PR TITLE
Refactor AST node structure

### DIFF
--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use crate::token::token::Token;
 
-use super::{ChainCommandAstNode, Command, CommandType, ExtCommandAstNode};
+use super::{ChainCommandAstNode, Command, CommandType, ExeCommandAstNode};
 
 #[derive(Debug, Clone)]
 pub struct LsCommand {
@@ -41,7 +41,7 @@ impl Command for LsCommand {
     }
 }
 
-impl ExtCommandAstNode for LsCommand {
+impl ExeCommandAstNode for LsCommand {
     fn set_options(&mut self, options: Vec<(String, String)>) {
         for (option, value) in options {
             self.option.insert(option, value);
@@ -56,7 +56,7 @@ impl ExtCommandAstNode for LsCommand {
         self.value = values;
     }
 
-    fn clone_ext_cmd(&self) -> Box<dyn ExtCommandAstNode> {
+    fn clone_ext_cmd(&self) -> Box<dyn ExeCommandAstNode> {
         Box::new(self.clone())
     }
 }
@@ -98,7 +98,7 @@ impl Command for CdCommand {
     }
 }
 
-impl ExtCommandAstNode for CdCommand {
+impl ExeCommandAstNode for CdCommand {
     fn set_options(&mut self, options: Vec<(String, String)>) {
         for (option, value) in options {
             self.option.insert(option, value);
@@ -113,7 +113,7 @@ impl ExtCommandAstNode for CdCommand {
         self.value = values;
     }
 
-    fn clone_ext_cmd(&self) -> Box<dyn ExtCommandAstNode> {
+    fn clone_ext_cmd(&self) -> Box<dyn ExeCommandAstNode> {
         Box::new(self.clone())
     }
 }
@@ -122,8 +122,8 @@ impl ExtCommandAstNode for CdCommand {
 pub struct PipeCommand {
     command_type: CommandType,
     token: Token,
-    data_source: Box<dyn ExtCommandAstNode>,
-    data_destination: Box<dyn ExtCommandAstNode>,
+    data_source: Box<dyn ExeCommandAstNode>,
+    data_destination: Box<dyn ExeCommandAstNode>,
 }
 
 impl Clone for PipeCommand {
@@ -156,11 +156,11 @@ impl Command for PipeCommand {
 }
 
 impl ChainCommandAstNode for PipeCommand {
-    fn set_source(&mut self, values: Box<dyn ExtCommandAstNode>) {
+    fn set_source(&mut self, values: Box<dyn ExeCommandAstNode>) {
         self.data_source = values;
     }
 
-    fn set_destination(&mut self, values: Box<dyn ExtCommandAstNode>) {
+    fn set_destination(&mut self, values: Box<dyn ExeCommandAstNode>) {
         self.data_destination = values;
     }
 

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use crate::token::token::Token;
 
-use super::{ChainCommandAstNode, Command, CommandType, ExeCommandAstNode};
+use super::{Command, CommandType};
 
 #[derive(Debug, Clone)]
 pub struct LsCommand {
@@ -32,16 +32,6 @@ impl Command for LsCommand {
         &self.command_type
     }
 
-    fn clone_cmd(&self) -> Box<dyn Command> {
-        Box::new(self.clone())
-    }
-
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
-    }
-}
-
-impl ExeCommandAstNode for LsCommand {
     fn set_options(&mut self, options: Vec<(String, String)>) {
         for (option, value) in options {
             self.option.insert(option, value);
@@ -56,7 +46,11 @@ impl ExeCommandAstNode for LsCommand {
         self.value = values;
     }
 
-    fn clone_ext_cmd(&self) -> Box<dyn ExeCommandAstNode> {
+    fn set_source(&mut self, _values: Option<Box<dyn Command>>) {}
+
+    fn set_destination(&mut self, _values: Option<Box<dyn Command>>) {}
+
+    fn clone_cmd(&self) -> Box<dyn Command> {
         Box::new(self.clone())
     }
 }
@@ -89,16 +83,6 @@ impl Command for CdCommand {
         &self.command_type
     }
 
-    fn clone_cmd(&self) -> Box<dyn Command> {
-        Box::new(self.clone())
-    }
-
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
-    }
-}
-
-impl ExeCommandAstNode for CdCommand {
     fn set_options(&mut self, options: Vec<(String, String)>) {
         for (option, value) in options {
             self.option.insert(option, value);
@@ -109,11 +93,13 @@ impl ExeCommandAstNode for CdCommand {
         self.option.get(option).map(|s| s.as_str())
     }
 
-    fn set_values(&mut self, values: Vec<String>) {
-        self.value = values;
-    }
+    fn set_values(&mut self, _values: Vec<String>) {}
 
-    fn clone_ext_cmd(&self) -> Box<dyn ExeCommandAstNode> {
+    fn set_source(&mut self, _values: Option<Box<dyn Command>>) {}
+
+    fn set_destination(&mut self, _values: Option<Box<dyn Command>>) {}
+
+    fn clone_cmd(&self) -> Box<dyn Command> {
         Box::new(self.clone())
     }
 }
@@ -122,8 +108,8 @@ impl ExeCommandAstNode for CdCommand {
 pub struct PipeCommand {
     command_type: CommandType,
     token: Token,
-    data_source: Box<dyn ExeCommandAstNode>,
-    data_destination: Box<dyn ExeCommandAstNode>,
+    data_source: Box<dyn Command>,
+    data_destination: Box<dyn Command>,
 }
 
 impl Clone for PipeCommand {
@@ -146,25 +132,23 @@ impl Command for PipeCommand {
         &self.command_type
     }
 
-    fn clone_cmd(&self) -> Box<dyn Command> {
-        Box::new(self.clone())
+    fn set_options(&mut self, _options: Vec<(String, String)>) {}
+
+    fn get_option(&self, _option: &str) -> Option<&str> {
+        None
     }
 
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
-    }
-}
+    fn set_values(&mut self, _values: Vec<String>) {}
 
-impl ChainCommandAstNode for PipeCommand {
-    fn set_source(&mut self, values: Box<dyn ExeCommandAstNode>) {
+    fn set_source(&mut self, values: Box<dyn Command>) {
         self.data_source = values;
     }
 
-    fn set_destination(&mut self, values: Box<dyn ExeCommandAstNode>) {
+    fn set_destination(&mut self, values: Box<dyn Command>) {
         self.data_destination = values;
     }
 
-    fn clone_chain_cmd(&self) -> Box<dyn ChainCommandAstNode> {
+    fn clone_cmd(&self) -> Box<dyn Command> {
         Box::new(self.clone())
     }
 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -15,21 +15,10 @@ pub trait Command: std::fmt::Debug {
     // Get Command type.
     fn get_type(&self) -> &CommandType;
 
-    // Clone the command to Box<dyn Command>.
-    fn clone_cmd(&self) -> Box<dyn Command>;
+    /// Only commands of the [`ExtCommand`] type have options and values.
+    /// The following functions: [`set_options`], [`get_option`], [`set_values`], and [`clone_ext_cmd`]
+    /// are used to set and retrieve the options and values for an execute command.
 
-    // Get the command as any.
-    fn as_any(&self) -> &dyn std::any::Any;
-}
-
-impl Clone for Box<dyn Command> {
-    fn clone(&self) -> Box<dyn Command> {
-        self.clone_cmd()
-    }
-}
-
-// The CommandAstNode trait is used to define the common interface for the command AST node.
-pub trait ExeCommandAstNode: std::fmt::Debug + Command {
     // Set the command option.
     fn set_options(&mut self, options: Vec<(String, String)>);
 
@@ -39,32 +28,22 @@ pub trait ExeCommandAstNode: std::fmt::Debug + Command {
     // Add the command value.
     fn set_values(&mut self, values: Vec<String>);
 
-    // Clone the command to Box<dyn ExtCommandAstNode>.
-    fn clone_ext_cmd(&self) -> Box<dyn ExeCommandAstNode>;
+    /// Only commands of the [`ChainCommand`] type have a data source and a data destination.
+    /// The following functions: [`set_source`] and [`set_destination`]
+    /// are used to set the data source and data destination for a chain command.
+
+    /// Set the data source from the command whose type is [`ExtCommand`].
+    fn set_source(&mut self, values: Option<Box<dyn Command>>);
+
+    /// Set the data destination to the next execute command.
+    fn set_destination(&mut self, values: Option<Box<dyn Command>>);
+
+    // Clone the command to Box<dyn Command>.
+    fn clone_cmd(&self) -> Box<dyn Command>;
 }
 
-
-// The CommandAstNode trait is used to define the common interface for the command AST node.
-impl Clone for Box<dyn ExeCommandAstNode> {
-    fn clone(&self) -> Box<dyn ExeCommandAstNode> {
-        self.clone_ext_cmd()
-    }
-}
-
-pub trait ChainCommandAstNode: std::fmt::Debug + Command {
-    /// Set the data source from [`ExeCommandAstNode`].
-    fn set_source(&mut self, values: Box<dyn ExeCommandAstNode>);
-
-    // Set the data destination to [`CommandAstNode`].
-    fn set_destination(&mut self, values: Box<dyn ExeCommandAstNode>);
-
-    // Clone the command to Box<dyn ChainCommandAstNode>.
-    fn clone_chain_cmd(&self) -> Box<dyn ChainCommandAstNode>;
-}
-
-// The CommandAstNode trait is used to define the common interface for the command AST node.
-impl Clone for Box<dyn ChainCommandAstNode> {
-    fn clone(&self) -> Box<dyn ChainCommandAstNode> {
-        self.clone_chain_cmd()
+impl Clone for Box<dyn Command> {
+    fn clone(&self) -> Box<dyn Command> {
+        self.clone_cmd()
     }
 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -29,7 +29,7 @@ impl Clone for Box<dyn Command> {
 }
 
 // The CommandAstNode trait is used to define the common interface for the command AST node.
-pub trait ExtCommandAstNode: std::fmt::Debug + Command {
+pub trait ExeCommandAstNode: std::fmt::Debug + Command {
     // Set the command option.
     fn set_options(&mut self, options: Vec<(String, String)>);
 
@@ -40,23 +40,23 @@ pub trait ExtCommandAstNode: std::fmt::Debug + Command {
     fn set_values(&mut self, values: Vec<String>);
 
     // Clone the command to Box<dyn ExtCommandAstNode>.
-    fn clone_ext_cmd(&self) -> Box<dyn ExtCommandAstNode>;
+    fn clone_ext_cmd(&self) -> Box<dyn ExeCommandAstNode>;
 }
 
 
 // The CommandAstNode trait is used to define the common interface for the command AST node.
-impl Clone for Box<dyn ExtCommandAstNode> {
-    fn clone(&self) -> Box<dyn ExtCommandAstNode> {
+impl Clone for Box<dyn ExeCommandAstNode> {
+    fn clone(&self) -> Box<dyn ExeCommandAstNode> {
         self.clone_ext_cmd()
     }
 }
 
 pub trait ChainCommandAstNode: std::fmt::Debug + Command {
-    /// Set the data source from [`ExtCommandAstNode`].
-    fn set_source(&mut self, values: Box<dyn ExtCommandAstNode>);
+    /// Set the data source from [`ExeCommandAstNode`].
+    fn set_source(&mut self, values: Box<dyn ExeCommandAstNode>);
 
     // Set the data destination to [`CommandAstNode`].
-    fn set_destination(&mut self, values: Box<dyn ExtCommandAstNode>);
+    fn set_destination(&mut self, values: Box<dyn ExeCommandAstNode>);
 
     // Clone the command to Box<dyn ChainCommandAstNode>.
     fn clone_chain_cmd(&self) -> Box<dyn ChainCommandAstNode>;

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -7,7 +7,7 @@ use crate::{
 
 use super::{
     ast::{CdCommand, LsCommand},
-    Command, ExtCommandAstNode,
+    Command, ExeCommandAstNode,
 };
 
 // This parser is a recursive descent parser.

--- a/tests/parser_test.rs
+++ b/tests/parser_test.rs
@@ -2,12 +2,12 @@
 mod parser_test {
     use ru_shell::parser::ast::{CdCommand, LsCommand};
     use ru_shell::parser::parser::Parser;
-    use ru_shell::parser::{Command, ExtCommandAstNode};
+    use ru_shell::parser::{Command, ExeCommandAstNode};
     use ru_shell::token::token::{Token, TokenType};
 
     #[test]
     fn test_show_command() {
-        let mut command_ast: Vec<Box<dyn ExtCommandAstNode>> = Vec::new();
+        let mut command_ast: Vec<Box<dyn ExeCommandAstNode>> = Vec::new();
 
         let mut ls_command = LsCommand::new(Token::new(TokenType::Ls, "ls".to_string()));
         ls_command.set_options(vec![


### PR DESCRIPTION
- Remove `ExeCommandAstNode` and `ChainCommandAstNode`.
- Introduce new functions in `Command` and redesign its structure.
- Reimplement the `Command` trait for `LsCommand`, `CdCommand`, and `PipCommand`, utilizing `CommandType` for differentiation.
