### PR TITLE
Dev0.1.0/parser

### DIFF
--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -5,16 +5,16 @@ use crate::token::token::Token;
 use super::{Command, CommandType};
 
 #[derive(Debug, Clone)]
-pub struct LsCommand {
+pub struct ExeCommand {
     command_type: CommandType,
     token: Token,
     option: HashMap<String, String>,
     values: Vec<String>,
 }
 
-impl LsCommand {
+impl ExeCommand {
     pub fn new(token: Token) -> Self {
-        LsCommand {
+        ExeCommand {
             token,
             option: HashMap::new(),
             values: Vec::new(),
@@ -23,58 +23,7 @@ impl LsCommand {
     }
 }
 
-impl Command for LsCommand {
-    fn name(&self) -> &str {
-        self.token.literal()
-    }
-
-    fn get_type(&self) -> &CommandType {
-        &self.command_type
-    }
-
-    fn set_options(&mut self, options: Vec<(String, String)>) {
-        for (option, value) in options {
-            self.option.insert(option, value);
-        }
-    }
-
-    fn get_option(&self, option: &str) -> Option<&str> {
-        self.option.get(option).map(|s| s.as_str())
-    }
-
-    fn set_values(&mut self, values: Vec<String>) {
-        self.values = values;
-    }
-
-    fn set_source(&mut self, _values: Option<Box<dyn Command>>) {}
-
-    fn set_destination(&mut self, _values: Option<Box<dyn Command>>) {}
-
-    fn clone_cmd(&self) -> Box<dyn Command> {
-        Box::new(self.clone())
-    }
-}
-
-#[derive(Debug, Clone)]
-pub struct CdCommand {
-    command_type: CommandType,
-    token: Token,
-    option: HashMap<String, String>,
-    values: Vec<String>,
-}
-
-impl CdCommand {
-    pub fn new(token: Token) -> Self {
-        CdCommand {
-            token,
-            option: HashMap::new(),
-            values: Vec::new(),
-            command_type: CommandType::ExtCommand,
-        }
-    }
-}
-
-impl Command for CdCommand {
+impl Command for ExeCommand {
     fn name(&self) -> &str {
         self.token.literal()
     }
@@ -107,14 +56,25 @@ impl Command for CdCommand {
 }
 
 #[derive(Debug)]
-pub struct PipeCommand {
+pub struct ChainCommand {
     command_type: CommandType,
     token: Token,
-    data_source: Box<dyn Command>,
-    data_destination: Box<dyn Command>,
+    data_source: Option<Box<dyn Command>>,
+    data_destination: Option<Box<dyn Command>>,
 }
 
-impl Clone for PipeCommand {
+impl ChainCommand {
+    pub fn new(token: Token) -> Self {
+        ChainCommand {
+            token,
+            command_type: CommandType::ChainCommand,
+            data_source: None,
+            data_destination: None,
+        }
+    }
+}
+
+impl Clone for ChainCommand {
     fn clone(&self) -> Self {
         Self {
             command_type: self.command_type.clone(),
@@ -125,7 +85,7 @@ impl Clone for PipeCommand {
     }
 }
 
-impl Command for PipeCommand {
+impl Command for ChainCommand {
     fn name(&self) -> &str {
         self.token.literal()
     }
@@ -143,11 +103,11 @@ impl Command for PipeCommand {
     fn set_values(&mut self, _values: Vec<String>) {}
 
     fn set_source(&mut self, values: Option<Box<dyn Command>>) {
-        self.data_source = values.unwrap();
+        self.data_source = values;
     }
 
     fn set_destination(&mut self, values: Option<Box<dyn Command>>) {
-        self.data_destination = values.unwrap();
+        self.data_destination = values;
     }
 
     fn clone_cmd(&self) -> Box<dyn Command> {

--- a/src/token/token.rs
+++ b/src/token/token.rs
@@ -74,18 +74,4 @@ impl Token {
     pub fn token_type(&self) -> &TokenType {
         &self.token_type
     }
-
-    pub fn priority(&self) -> u8 {
-        match self.token_type {
-            TokenType::Pipe => 5,
-            TokenType::Background => 5,
-            TokenType::Ls => 4,
-            TokenType::Cd => 4,
-            TokenType::ShortParam => 3,
-            TokenType::LongParam => 3,
-            TokenType::Assignment => 2,
-            TokenType::Literal => 1,
-            _ => 0,
-        }
-    }
 }

--- a/tests/parser_test.rs
+++ b/tests/parser_test.rs
@@ -1,15 +1,15 @@
 #[cfg(test)]
 mod parser_test {
-    use ru_shell::parser::ast::{CdCommand, LsCommand};
+    use ru_shell::parser::ast::ExeCommand;
     use ru_shell::parser::parser::Parser;
-    use ru_shell::parser::{Command, ExeCommandAstNode};
+    use ru_shell::parser::Command;
     use ru_shell::token::token::{Token, TokenType};
 
     #[test]
     fn test_show_command() {
-        let mut command_ast: Vec<Box<dyn ExeCommandAstNode>> = Vec::new();
+        let mut command_ast: Vec<Box<dyn Command>> = Vec::new();
 
-        let mut ls_command = LsCommand::new(Token::new(TokenType::Ls, "ls".to_string()));
+        let mut ls_command = ExeCommand::new(Token::new(TokenType::Ls, "ls".to_string()));
         ls_command.set_options(vec![
             ("-l".to_string(), "".to_string()),
             ("-h".to_string(), "".to_string()),
@@ -20,7 +20,7 @@ mod parser_test {
 
         command_ast.push(Box::new(ls_command));
 
-        println!("{:#?}", command_ast);
+        // println!("{:#?}", command_ast);
     }
 
     #[test]
@@ -30,16 +30,15 @@ mod parser_test {
         );
 
         parser.iter().for_each(|command| {
-            let c = command.as_any().downcast_ref::<LsCommand>().unwrap();
-            assert_eq!(c.name(), "ls");
+            assert_eq!(command.name(), "ls");
             assert_eq!(
                 command.get_type(),
                 &ru_shell::parser::CommandType::ExtCommand
             );
-            assert_eq!(c.get_option("-l"), Some(""));
-            assert_eq!(c.get_option("-h"), Some(""));
-            assert_eq!(c.get_option("--tree"), Some(""));
-            assert_eq!(c.get_option("--depth"), Some("3"));
+            assert_eq!(command.get_option("-l"), Some(""));
+            assert_eq!(command.get_option("-h"), Some(""));
+            assert_eq!(command.get_option("--tree"), Some(""));
+            assert_eq!(command.get_option("--depth"), Some("3"));
         });
     }
 
@@ -48,8 +47,7 @@ mod parser_test {
         let parser = Parser::new("cd ~/Programs/Rust/ru-shell,Programs/Rust/ru-shell");
 
         parser.iter().for_each(|command| {
-            let c = command.as_any().downcast_ref::<CdCommand>().unwrap();
-            assert_eq!(c.name(), "cd");
+            assert_eq!(command.name(), "cd");
             assert_eq!(
                 command.get_type(),
                 &ru_shell::parser::CommandType::ExtCommand


### PR DESCRIPTION
- Remove 'LsCommand' and 'CdCommand', retain 'ExeCommand' to abstract all execution commands. Determine the type of 'ExeCommand' based on tokens.
- Separate out parse_exe_cmd for parsing execution commands, and separate out parse_chain_cmd for parsing chain commands.