### PR TITLE
Implement the 'From' trait for 'LsCmd'

### DIFF
--- a/src/executor/executor.rs
+++ b/src/executor/executor.rs
@@ -1,7 +1,8 @@
 use crate::executor::Command;
-
-use crate::parser::parser::ParserIterator;
+use crate::executor::ls::LsCmd;
 use crate::parser::{CommandAstNode, CommandType};
+use crate::parser::parser::ParserIterator;
+use crate::token::token::TokenType;
 
 // This executor obtains the commands to be executed
 // and their relevant parameters by parsing the AST,
@@ -28,7 +29,7 @@ impl Executor {
 
     // Add command to cmds that was analyzed
     pub fn add_cmd(&mut self, cmd: Box<dyn CommandAstNode>) {
-        let cmd = match cmd.get_type() {
+        let cmd = match cmd.cmd_type() {
             CommandType::ExtCommand => self.analyze_exe_node(cmd),
             CommandType::ChainCommand => self.analyze_chain_node(cmd),
         };
@@ -38,8 +39,8 @@ impl Executor {
 
     /// Analyze the AST which type is [`parser::CommandType::ExtCommand`].
     fn analyze_exe_node(&mut self, cmd: Box<dyn CommandAstNode>) -> Box<dyn Command> {
-        match cmd.name() {
-            "ls" => self.analyze_ls_node(),
+        match cmd.token_type() {
+            TokenType::Ls => Box::new(LsCmd::from(cmd)),
             _ => {
                 todo!()
             }
@@ -48,18 +49,13 @@ impl Executor {
 
     /// Analyze the AST which type is [`parser::CommandType::ChainCommand`].
     fn analyze_chain_node(&mut self, cmd: Box<dyn CommandAstNode>) -> Box<dyn Command> {
-        match cmd.name() {
-            "|" => {
+        match cmd.token_type() {
+            TokenType::Pipe => {
                 todo!()
             }
             _ => {
                 todo!()
             }
         }
-    }
-
-    // Analyze the 'ls' command AST node.
-    fn analyze_ls_node(&self) -> Box<dyn Command> {
-        todo!()
     }
 }

--- a/src/executor/ls.rs
+++ b/src/executor/ls.rs
@@ -1,5 +1,32 @@
-use crate::executor::Command;
-use std::{collections::HashMap, path::PathBuf};
+use std::path::PathBuf;
+
+use colored::{ColoredString, Colorize};
+
+use crate::{executor::Command, parser::CommandAstNode};
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+enum FileType {
+    File,
+    Dir,
+    Link,
+    CharDevice,
+    BlockDevice,
+    Fifo,
+    Socket,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct FileInfo {
+    file_type: FileType,
+    permissions: String,
+    link: u64,
+    owner: String,
+    group: String,
+    size: u64,
+    modified_time: String,
+    name: String,
+    is_hidden: bool,
+}
 
 // Ls command
 pub struct LsCmd {
@@ -15,6 +42,12 @@ pub struct LsCmd {
     // reverse sort
     resort: bool,
 
+    // show files and directories as a tree
+    tree: bool,
+
+    // set the depth of the tree, default is 10
+    depth: u8,
+
     // set file or directory path
     path: Vec<PathBuf>,
 
@@ -23,9 +56,9 @@ pub struct LsCmd {
     // 'ls -l'                  => status-1 : show details of files and directories
     // 'ls -a'                  => status-2 : show hidden files and directories
     // 'ls -a -l'               => status-3 : calculated by 1 | 2, it will show details of all hidden files and directories
-    // 'ls -H'                  => status-4 : set status to 4, but do nothing, don't ask why, Linux ls command also do nothing when get '-h' option
-    // 'ls -l -H'               => status-5 : calculated by 1 | 4, it will show details of files and directories with human readable file sizes
-    // 'ls -a -l -H'            => status-7 : calculated by 1 | 2 | 4, it will show details of all hidden files and directories with human readable file sizes
+    // 'ls -h'                  => status-4 : set status to 4, but do nothing, don't ask why, Linux ls command also do nothing when get '-h' option
+    // 'ls -l -h'               => status-5 : calculated by 1 | 4, it will show details of files and directories with human readable file sizes
+    // 'ls -a -l -h'            => status-7 : calculated by 1 | 2 | 4, it will show details of all hidden files and directories with human readable file sizes
     // 'ls -t' of 'ls --tree'   => status-8 : show files and directories as a tree
     // other command            => status-0 : default status
     // Above status were set by the parse function what we implemented in the impl code block.
@@ -36,16 +69,112 @@ pub struct LsCmd {
 }
 
 impl LsCmd {
-    // Create new LsCmd
-    pub fn new(options: &HashMap<String, String>) -> Self {
+    fn new() -> Self {
         Self {
             long: false,
             all: false,
             human_readable: false,
             resort: false,
+            tree: false,
+            depth: 10,
             path: Vec::new(),
             status: 0,
         }
+    }
+
+    // Set status of the command
+    fn init_status(&mut self) {
+        // Set status to 0 by default
+        self.status = 0;
+
+        // Set status to 1 if get '-l' option
+        if self.long {
+            self.status |= 1;
+        }
+
+        // Set status to 2 if get '-a' option
+        if self.all {
+            self.status |= 2;
+        }
+
+        // Set status to 4 if get '-H' option
+        if self.human_readable {
+            self.status |= 4;
+        }
+
+        if self.tree {
+            self.status |= 8;
+        }
+    }
+
+    // Get status of the command
+    fn get_status(&self) -> u8 {
+        self.status
+    }
+
+    // Color file name by file type when show file names.
+    fn color_file_names(&self, file: &FileInfo) -> ColoredString {
+        match file.file_type {
+            FileType::File => file.name.white(),
+            FileType::Dir => file.name.cyan(),
+            FileType::Link => file.name.blue(),
+            FileType::CharDevice | FileType::BlockDevice | FileType::Fifo | FileType::Socket => {
+                file.name.green()
+            }
+        }
+    }
+}
+
+impl From<Box<dyn CommandAstNode>> for LsCmd {
+    fn from(cmd: Box<dyn CommandAstNode>) -> Self {
+        let mut ls_cmd = Self::new();
+
+        // Get the paths from 'cmd.values'
+        ls_cmd.path = match cmd.get_values() {
+            Some(values) => values.into_iter().map(PathBuf::from).collect(),
+            None => Vec::new(),
+        };
+
+        // Get the 'long' option
+        match cmd.get_option("-l").or(cmd.get_option("--long")) {
+            Some(_) => ls_cmd.long = true,
+            None => ls_cmd.long = false,
+        }
+
+        // Get the 'all' option
+        match cmd.get_option("-a").or(cmd.get_option("--all")) {
+            Some(_) => ls_cmd.all = true,
+            None => ls_cmd.all = false,
+        }
+
+        // Get the 'human_readable' option
+        match cmd.get_option("-h").or(cmd.get_option("--human-readable")) {
+            Some(_) => ls_cmd.human_readable = true,
+            None => ls_cmd.human_readable = false,
+        }
+
+        // Get the 'resort' option
+        match cmd.get_option("-r").or(cmd.get_option("--resort")) {
+            Some(_) => ls_cmd.resort = true,
+            None => ls_cmd.resort = false,
+        }
+
+        // Get the 'tree' option
+        match cmd.get_option("--tree") {
+            Some(_) => ls_cmd.tree = true,
+            None => ls_cmd.tree = false,
+        }
+
+        // Get the 'depth' option
+        match cmd.get_option("--depth") {
+            Some(depth) => ls_cmd.depth = depth.parse::<u8>().unwrap_or(10),
+            None => ls_cmd.depth = 10,
+        }
+
+        // Initialize the status
+        ls_cmd.init_status();
+
+        ls_cmd
     }
 }
 

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use crate::token::token::Token;
+use crate::token::token::{Token, TokenType};
 
 use super::{CommandAstNode, CommandType};
 
@@ -24,11 +24,11 @@ impl ExeCommandAstNode {
 }
 
 impl CommandAstNode for ExeCommandAstNode {
-    fn name(&self) -> &str {
-        self.token.literal()
+    fn token_type(&self) -> &TokenType {
+        self.token.token_type()
     }
 
-    fn get_type(&self) -> &CommandType {
+    fn cmd_type(&self) -> &CommandType {
         &self.command_type
     }
 
@@ -94,11 +94,11 @@ impl Clone for ChainCommandAstNode {
 }
 
 impl CommandAstNode for ChainCommandAstNode {
-    fn name(&self) -> &str {
-        self.token.literal()
+    fn token_type(&self) -> &TokenType {
+        self.token.token_type()
     }
 
-    fn get_type(&self) -> &CommandType {
+    fn cmd_type(&self) -> &CommandType {
         &self.command_type
     }
 

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -9,7 +9,7 @@ pub struct ExeCommandAstNode {
     command_type: CommandType,
     token: Token,
     option: HashMap<String, String>,
-    values: Vec<String>,
+    values: Option<Vec<String>>,
 }
 
 impl ExeCommandAstNode {
@@ -17,7 +17,7 @@ impl ExeCommandAstNode {
         ExeCommandAstNode {
             token,
             option: HashMap::new(),
-            values: Vec::new(),
+            values: None,
             command_type: CommandType::ExtCommand,
         }
     }
@@ -43,7 +43,11 @@ impl CommandAstNode for ExeCommandAstNode {
     }
 
     fn set_values(&mut self, values: Vec<String>) {
-        self.values = values;
+        self.values = Some(values);
+    }
+
+    fn get_values(&self) -> Option<Vec<String>> {
+        self.values.clone()
     }
 
     fn set_source(&mut self, _values: Option<Box<dyn CommandAstNode>>) {}
@@ -109,6 +113,10 @@ impl CommandAstNode for ChainCommandAstNode {
     }
 
     fn set_values(&mut self, _values: Vec<String>) {}
+
+    fn get_values(&self) -> Option<Vec<String>> {
+        None
+    }
 
     fn set_source(&mut self, values: Option<Box<dyn CommandAstNode>>) {
         self.data_source = values;

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1,3 +1,5 @@
+use crate::token::token::TokenType;
+
 pub mod ast;
 pub mod parser;
 
@@ -9,11 +11,11 @@ pub enum CommandType {
 
 // This trait is used to define the command,
 pub trait CommandAstNode: std::fmt::Debug {
-    // Get the command name.
-    fn name(&self) -> &str;
+    // Get the command token type.
+    fn token_type(&self) -> &TokenType;
 
     // Get Command type.
-    fn get_type(&self) -> &CommandType;
+    fn cmd_type(&self) -> &CommandType;
 
     /// Only commands of the [`ExtCommand`] type have options and values.
     /// The following functions: [`set_options`], [`get_option`], [`set_values`], and [`clone_ext_cmd`]

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -27,8 +27,11 @@ pub trait CommandAstNode: std::fmt::Debug {
     // Get the command option.
     fn get_option(&self, option: &str) -> Option<&str>;
 
-    // Add the command value.
+    // Add the command values.
     fn set_values(&mut self, values: Vec<String>);
+
+    // Get the command values.
+    fn get_values(&self) -> Option<Vec<String>>;
 
     /// Only commands of the [`ChainCommand`] type have a data source and a data destination.
     /// The following functions: [`set_source`] and [`set_destination`]

--- a/tests/parser_test.rs
+++ b/tests/parser_test.rs
@@ -30,9 +30,9 @@ mod parser_test {
         );
 
         parser.iter().for_each(|command| {
-            assert_eq!(command.name(), "ls");
+            assert_eq!(command.token_type(), &TokenType::Ls);
             assert_eq!(
-                command.get_type(),
+                command.cmd_type(),
                 &ru_shell::parser::CommandType::ExtCommand
             );
             assert_eq!(command.get_option("-l"), Some(""));
@@ -47,9 +47,9 @@ mod parser_test {
         let parser = Parser::new("cd ~/Programs/Rust/ru-shell,Programs/Rust/ru-shell");
 
         parser.iter().for_each(|command| {
-            assert_eq!(command.name(), "cd");
+            assert_eq!(command.token_type(), &TokenType::Cd);
             assert_eq!(
-                command.get_type(),
+                command.cmd_type(),
                 &ru_shell::parser::CommandType::ExtCommand
             );
         });
@@ -58,16 +58,16 @@ mod parser_test {
     #[test]
     fn test_chain_command_parse() {
         let parser = Parser::new("ls -l -h | cd | ls --tree --depth=3");
-        
+
         let cmd = parser.iter().next().unwrap();
-        assert_eq!(cmd.get_type(), &ru_shell::parser::CommandType::ChainCommand);
-        assert_eq!(cmd.name(), "|");
-        assert_eq!(cmd.get_source().unwrap().name(), "ls");
-        assert_eq!(cmd.get_destination().unwrap().name(), "|");
+        assert_eq!(cmd.cmd_type(), &ru_shell::parser::CommandType::ChainCommand);
+        assert_eq!(cmd.token_type(), &TokenType::Pipe);
+        assert_eq!(cmd.get_source().unwrap().token_type(), &TokenType::Ls);
+        assert_eq!(cmd.get_destination().unwrap().token_type(), &TokenType::Pipe);
 
         let cmd2 = cmd.get_destination().unwrap();
-        assert_eq!(cmd2.get_source().unwrap().name(), "cd");
-        assert_eq!(cmd2.get_destination().unwrap().name(), "ls");
+        assert_eq!(cmd2.get_source().unwrap().token_type(), &TokenType::Cd);
+        assert_eq!(cmd2.get_destination().unwrap().token_type(), &TokenType::Ls);
         assert_eq!(cmd2.get_destination().unwrap().get_option("--tree"), Some(""));
         assert_eq!(cmd2.get_destination().unwrap().get_option("--depth"), Some("3"));
     }


### PR DESCRIPTION
Implement the 'From' trait for 'LsCmd' to enable the use of the 'from' function for creating an 'LsCmd' object from a 'CommandAstNode'.