### PR TITLE
Add parsing logical for 'grep' command

### DIFF
--- a/src/lexer/lexer.rs
+++ b/src/lexer/lexer.rs
@@ -202,7 +202,9 @@ impl Lexer {
                 | State::AssignmentState
                 | State::SlashState
                 | State::StarState
-                | State::TildeState => {
+                | State::TildeState
+                | State::QuoteState
+                | State::SingleQuoteState => {
                     self.store_token_and_trans_state(index, c);
                 }
 
@@ -264,12 +266,17 @@ impl Lexer {
         if !(state == State::WhiteSpace) {
             // Match the state to get the token type.
             let token_type = match state {
+                // =============== command ===============
                 State::LsCommandState => TokenType::Ls,
                 State::CdCommandState => TokenType::Cd,
                 State::GrepCommandState => TokenType::Grep,
+                State::PipeState => TokenType::Pipe,
+
+                // =============== parameter ===============
                 State::ShortParamState => TokenType::ShortParam,
                 State::LongParamState => TokenType::LongParam,
-                State::PipeState => TokenType::Pipe,
+
+                // =============== single symbols ===============
                 State::CommaState => TokenType::Comma,
                 State::SemicolonState => TokenType::Semicolon,
                 State::GreaterThanState => TokenType::GreaterThan,
@@ -277,14 +284,22 @@ impl Lexer {
                 State::DotState => TokenType::Dot,
                 State::ColonState => TokenType::Colon,
                 State::AssignmentState => TokenType::Assignment,
-                State::NumState => TokenType::Num,
                 State::SlashState => TokenType::Slash,
                 State::StarState => TokenType::Star,
                 State::BackgroundState => TokenType::Background,
+                State::TildeState => TokenType::Tilde,
+                State::QuoteState => TokenType::Quote,
+                State::SingleQuoteState => TokenType::SingleQuote,
+
+                // =============== combined symbols ===============
                 State::AndState => TokenType::And,
                 State::OrState => TokenType::Or,
-                State::TildeState => TokenType::Tilde,
+
+                // =============== literal ===============
                 State::Literal => TokenType::Literal,
+
+                // =============== number ===============
+                State::NumState => TokenType::Num,
                 _ => todo!(),
             };
 
@@ -364,6 +379,8 @@ impl Lexer {
             '*' => *state = State::StarState,
             '&' => *state = State::BackgroundState,
             '~' => *state = State::TildeState,
+            '"' => *state = State::QuoteState,
+            '\'' => *state = State::SingleQuoteState,
             '_' => {
                 if *state == State::StarState || *state == State::WhiteSpace {
                     *state = State::Literal;

--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -45,6 +45,8 @@ enum State {
     StarState,        // *
     BackgroundState,  // &
     TildeState,       // ~
+    QuoteState,       // "
+    SingleQuoteState, // '
 
     // Combined Symbols
     AndState, // &&

--- a/src/token/token.rs
+++ b/src/token/token.rs
@@ -37,6 +37,8 @@ pub enum TokenType {
     LeftBracket,  // [
     RightBracket, // ]
     Tilde,        // ~
+    Quote,        // "
+    SingleQuote,  // '
 
     // Combined Symbols
     DoubleMinus,          // --

--- a/tests/lexer_test.rs
+++ b/tests/lexer_test.rs
@@ -204,10 +204,10 @@ mod test {
 
     #[test]
     fn test_quote_token() {
-        let l = Lexer::new("echo \"hello world\" 'hello world'");
+        let l = Lexer::new("grep \"hello world\" 'hello world'");
 
         let tokens = vec![
-            Token::new(TokenType::Literal, "echo".to_string()),
+            Token::new(TokenType::Grep, "grep".to_string()),
             Token::new(TokenType::Quote, "\"".to_string()),
             Token::new(TokenType::Literal, "hello".to_string()),
             Token::new(TokenType::Literal, "world".to_string()),

--- a/tests/lexer_test.rs
+++ b/tests/lexer_test.rs
@@ -201,4 +201,29 @@ mod test {
             assert_eq!(token.literal(), next_token.literal());
         }
     }
+
+    #[test]
+    fn test_quote_token() {
+        let l = Lexer::new("echo \"hello world\" 'hello world'");
+
+        let tokens = vec![
+            Token::new(TokenType::Literal, "echo".to_string()),
+            Token::new(TokenType::Quote, "\"".to_string()),
+            Token::new(TokenType::Literal, "hello".to_string()),
+            Token::new(TokenType::Literal, "world".to_string()),
+            Token::new(TokenType::Quote, "\"".to_string()),
+            Token::new(TokenType::SingleQuote, "'".to_string()),
+            Token::new(TokenType::Literal, "hello".to_string()),
+            Token::new(TokenType::Literal, "world".to_string()),
+            Token::new(TokenType::SingleQuote, "'".to_string()),
+            Token::new(TokenType::Eof, "".to_string()),
+        ];
+
+        for token in tokens.iter() {
+            let next_token = l.next_token().unwrap();
+
+            assert_eq!(*token.token_type(), *next_token.token_type());
+            assert_eq!(token.literal(), next_token.literal());
+        }
+    }
 }

--- a/tests/parser_test.rs
+++ b/tests/parser_test.rs
@@ -63,12 +63,37 @@ mod parser_test {
         assert_eq!(cmd.cmd_type(), &ru_shell::parser::CommandType::ChainCommand);
         assert_eq!(cmd.token_type(), &TokenType::Pipe);
         assert_eq!(cmd.get_source().unwrap().token_type(), &TokenType::Ls);
-        assert_eq!(cmd.get_destination().unwrap().token_type(), &TokenType::Pipe);
+        assert_eq!(
+            cmd.get_destination().unwrap().token_type(),
+            &TokenType::Pipe
+        );
 
         let cmd2 = cmd.get_destination().unwrap();
         assert_eq!(cmd2.get_source().unwrap().token_type(), &TokenType::Cd);
         assert_eq!(cmd2.get_destination().unwrap().token_type(), &TokenType::Ls);
-        assert_eq!(cmd2.get_destination().unwrap().get_option("--tree"), Some(""));
-        assert_eq!(cmd2.get_destination().unwrap().get_option("--depth"), Some("3"));
+        assert_eq!(
+            cmd2.get_destination().unwrap().get_option("--tree"),
+            Some("")
+        );
+        assert_eq!(
+            cmd2.get_destination().unwrap().get_option("--depth"),
+            Some("3")
+        );
+    }
+
+    #[test]
+    fn test_grep_command_parse() {
+        let parser = Parser::new("grep -i -n -r \"main\" ~/Programs/Rust/ru-shell");
+
+        // println!("{:#?}", parser);
+
+        let cmd = parser.iter().next().unwrap();
+        assert_eq!(cmd.cmd_type(), &ru_shell::parser::CommandType::ExtCommand);
+        assert_eq!(cmd.token_type(), &TokenType::Grep);
+        assert_eq!(cmd.get_option("-i"), Some(""));
+        assert_eq!(cmd.get_option("-n"), Some(""));
+        assert_eq!(cmd.get_option("-r"), Some(""));
+        assert_eq!(cmd.get_values().unwrap()[0], "main");
+        assert_eq!(cmd.get_values().unwrap()[1], "~/Programs/Rust/ru-shell");
     }
 }


### PR DESCRIPTION
- Add function for 'Lexer' to parse quote and single-quote symbols tokens.
- Add parsing logical for 'grep' command and its pattern matching rules.
- Pass the test case of 'grep'.