### PR TITLE
Refactor the syntax parser

### DIFF
--- a/src/executor/grep.rs
+++ b/src/executor/grep.rs
@@ -180,22 +180,22 @@ impl From<Box<dyn CommandAstNode>> for GrepCmd {
         let mut grep_cmd = GrepCmd::new(pattern, file_buf);
 
         // Get options
-        match cmd.get_option("-i") {
+        match cmd.get_option("-i").or(cmd.get_option("--ignore-case")) {
             Some(_) => grep_cmd.ignore_case = true,
             None => grep_cmd.ignore_case = false,
         }
 
-        match cmd.get_option("-v") {
+        match cmd.get_option("-v").or(cmd.get_option("--invert-match")) {
             Some(_) => grep_cmd.invert_match = true,
             None => grep_cmd.invert_match = false,
         }
 
-        match cmd.get_option("-c") {
+        match cmd.get_option("-c").or(cmd.get_option("--count")) {
             Some(_) => grep_cmd.count = true,
             None => grep_cmd.count = false,
         }
 
-        match cmd.get_option("-n") {
+        match cmd.get_option("-n").or(cmd.get_option("--line-number")) {
             Some(_) => grep_cmd.show_line_number = true,
             None => grep_cmd.show_line_number = false,
         }

--- a/src/executor/ls.rs
+++ b/src/executor/ls.rs
@@ -57,7 +57,7 @@ pub struct LsCmd {
     sort_by_time: bool,
 
     // reverse sort
-    resort: bool,
+    reverse: bool,
 
     // show files and directories as a tree
     tree: bool,
@@ -95,7 +95,7 @@ impl LsCmd {
             human_readable: false,
             sort_by_size: false,
             sort_by_time: false,
-            resort: false,
+            reverse: false,
             tree: false,
             depth: 10,
             paths: Vec::new(),
@@ -468,7 +468,7 @@ impl LsCmd {
         }
 
         // Reverse sort if get '-r' option.
-        if self.resort {
+        if self.reverse {
             files.reverse();
         }
     }
@@ -514,9 +514,9 @@ impl From<Box<dyn CommandAstNode>> for LsCmd {
         }
 
         // Get the 'resort' option
-        match cmd.get_option("-r").or(cmd.get_option("--resort")) {
-            Some(_) => ls_cmd.resort = true,
-            None => ls_cmd.resort = false,
+        match cmd.get_option("-r").or(cmd.get_option("--reverse")) {
+            Some(_) => ls_cmd.reverse = true,
+            None => ls_cmd.reverse = false,
         }
 
         match cmd.get_option("-t").or(cmd.get_option("--time")) {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -3,12 +3,15 @@ use std::rc::Rc;
 
 use crate::lexer::Lexer;
 use crate::parser::ast_node_trait::CommandAstNode;
-use crate::parser::cmds_ast_node::{ChainCommandAstNode, ExeCommandAstNode};
+
 use crate::token::token::Token;
 use crate::token::token::TokenType;
 
+use self::cmds_ast_node::ChainCommandAstNode;
+
 pub mod ast_node_trait;
 pub mod cmds_ast_node;
+mod parsing_func;
 
 // Since the syntax of command-line interfaces is simpler than that of programming languages,
 // this parser analyzes and processes in the order of tokens.
@@ -105,7 +108,7 @@ impl Parser {
             if self.cur_token.borrow().clone().token_type() == &TokenType::Eof {
                 return;
             }
-            
+
             // Check if the current token is a command.
             if !self.check_wether_is_command() {
                 self.collect_error("Invalid command");
@@ -114,7 +117,7 @@ impl Parser {
 
             // Parse the corresponding command based on the token type
             // and return the parsed AST (Abstract Syntax Tree) node.
-            let ast_node: Box<dyn CommandAstNode> = match self.parse_exe_cmd() {
+            let ast_node: Box<dyn CommandAstNode> = match self.parse_cmd() {
                 Some(ext_cmd) => ext_cmd,
                 None => break,
             };
@@ -161,14 +164,14 @@ impl Parser {
     }
 
     // Parse the command whose type is execute command.
-    fn parse_exe_cmd(&self) -> Option<Box<dyn CommandAstNode>> {
+    fn parse_cmd(&self) -> Option<Box<dyn CommandAstNode>> {
         let cur_token = self.cur_token.borrow().clone();
         // Parse the corresponding command based on the token type
         // and return the parsed AST (Abstract Syntax Tree) node.
         let ext_cmd: Option<Box<dyn CommandAstNode>> = match cur_token.token_type() {
-            TokenType::Ls | TokenType::Cd | TokenType::Grep | TokenType::Cat => {
-                Some(self.parse_exe_command())
-            }
+            TokenType::Ls => self.parse_ls_cmd(),
+            TokenType::Cat => self.parse_cat_cmd(),
+            TokenType::Grep => self.parse_grep_cmd(),
             _ => None,
         };
 
@@ -184,7 +187,7 @@ impl Parser {
             // Move to next Token to parse
             self.next_token();
             // Set data destination of chain command.
-            let destination = self.parse_exe_cmd();
+            let destination = self.parse_cmd();
             cmd.set_destination(destination);
 
             return Some(Box::new(cmd));
@@ -199,220 +202,6 @@ impl Parser {
             return true;
         }
         false
-    }
-
-    // Parse execute command
-    fn parse_exe_command(&self) -> Box<dyn CommandAstNode> {
-        // Build the exe command node.
-        let mut exe_command = ExeCommandAstNode::new(self.cur_token.borrow().clone());
-
-        self.next_token();
-
-        // Parse the parameters of the ls command.
-        match self.parse_options() {
-            Some(params) => {
-                exe_command.set_options(params);
-            }
-            None => (),
-        };
-
-        // Parse the pattern of the grep command.
-        if exe_command.token_type() == &TokenType::Grep {
-            match self.parse_pattern() {
-                Some(paths) => exe_command.add_value(paths),
-                None => {
-                    return Box::new(exe_command);
-                }
-            };
-        }
-
-        // Parse the paths of the ls command.
-        match self.parse_paths() {
-            Some(paths) => exe_command.set_values(paths),
-            None => {
-                if exe_command.token_type() == &TokenType::Grep {
-                    self.collect_error("Grep command needs a path");
-                    return Box::new(exe_command);
-                }
-            }
-        };
-
-        match self.parse_chain_cmd() {
-            Some(mut token) => {
-                token.set_source(Some(Box::new(exe_command)));
-                token
-            }
-            None => Box::new(exe_command),
-        }
-    }
-
-    // Parse the matching rules of the 'Pattern matching' command.
-    fn parse_pattern(&self) -> Option<String> {
-        // If the current token is a double quotation mark, then the pattern is complete.
-        if *self.cur_token.borrow().token_type() == TokenType::Quote {
-            self.next_token();
-        } else {
-            self.collect_error("Missing pattern. You can use `\"` to quote the pattern.");
-            return None;
-        }
-
-        // Iterate through the subsequent tokens and add them to the current pattern
-        // until the condition is not met.
-        let mut pattern = String::from("");
-        loop {
-            if *self.cur_token.borrow().token_type() == TokenType::Literal
-                || *self.cur_token.borrow().token_type() == TokenType::Num
-                || *self.cur_token.borrow().token_type() == TokenType::Slash
-                || *self.cur_token.borrow().token_type() == TokenType::Dot
-                || *self.cur_token.borrow().token_type() == TokenType::Tilde
-            {
-                pattern.push_str(self.cur_token.borrow().literal());
-                self.next_token();
-            } else {
-                break;
-            }
-        }
-
-        // If the current token is a double quotation mark, then the pattern is complete.
-        if *self.cur_token.borrow().token_type() == TokenType::Quote {
-            self.next_token();
-        } else {
-            self.collect_error("Invalid pattern, missing right quotation mark.");
-            return None;
-        }
-
-        Some(pattern)
-    }
-
-    // Parse the paths of the command.
-    fn parse_paths(&self) -> Option<Vec<String>> {
-        let mut paths: Vec<String> = Vec::new();
-
-        loop {
-            let cur_token = self.cur_token.borrow().clone();
-            match *cur_token.token_type() {
-                TokenType::Tilde
-                | TokenType::Literal
-                | TokenType::Num
-                | TokenType::Slash
-                | TokenType::Dot => {
-                    paths.push(self.parse_path().unwrap());
-                }
-                _ => break,
-            };
-
-            // Skip the comma and get next path.
-            // If the current token isn't comma, then break the loop.
-            if self.cur_token.borrow().clone().token_type() != &TokenType::Comma {
-                break;
-            } else {
-                self.next_token();
-            }
-        }
-
-        if paths.is_empty() {
-            return None;
-        } else {
-            return Some(paths);
-        }
-    }
-
-    // Parse the path of the command.
-    fn parse_path(&self) -> Option<String> {
-        let mut path = String::from(self.cur_token.borrow().literal());
-        self.next_token();
-
-        loop {
-            if self.lexer.peek_token().is_none() {
-                break;
-            }
-
-            if *self.cur_token.borrow().token_type() == TokenType::Literal
-                || *self.cur_token.borrow().token_type() == TokenType::Num
-                || *self.cur_token.borrow().token_type() == TokenType::Slash
-                || *self.cur_token.borrow().token_type() == TokenType::Dot
-                || *self.cur_token.borrow().token_type() == TokenType::Tilde
-            {
-                path.push_str(self.cur_token.borrow().literal());
-                self.next_token();
-            } else {
-                break;
-            }
-        }
-
-        Some(path)
-    }
-
-    // Parse the parameters of the command.
-    fn parse_options(&self) -> Option<Vec<(String, String)>> {
-        let mut params: Vec<(String, String)> = Vec::new();
-
-        loop {
-            // If the current token isn't a parameter, then break the loop.
-            let cur_token = self.cur_token.borrow().clone();
-            match cur_token.token_type() {
-                TokenType::ShortParam | TokenType::LongParam => {
-                    match self.parse_option() {
-                        Some((param, value)) => {
-                            params.push((param, value));
-                        }
-                        None => break,
-                    };
-                }
-                _ => break,
-            };
-        }
-
-        Some(params)
-    }
-
-    // Parse the parameters of the command.
-    fn parse_option(&self) -> Option<(String, String)> {
-        let cur_token = self.cur_token.borrow().clone();
-
-        // Get the parameter and its value.
-        if *cur_token.token_type() == TokenType::ShortParam
-            || *cur_token.token_type() == TokenType::LongParam
-        {
-            let param = cur_token.literal().to_string();
-
-            self.next_token();
-
-            let value = self.parse_param_value().unwrap_or_else(|| "".to_string());
-
-            return Some((param, value));
-        }
-
-        None
-    }
-
-    // Parse the value of the parameter.
-    // The reason why the value of the parameter is optional is that
-    // user can set the value like this:
-    // 1. ls -l                 : the '-l' parameter has no value.
-    // 2. ls --tree --depth 3   : the value '3' is assigned to the '--depth' parameter without '='.
-    // 3. ls --color=auto       : the value 'auto' is assigned to the '--color' parameter with '='.
-    // So it is necessary to check in what way the value is assigned to the parameter.
-    fn parse_param_value(&self) -> Option<String> {
-        let cur_token = self.cur_token.borrow().clone();
-
-        // Skip the assignment operator.
-        if *cur_token.token_type() == TokenType::Assignment {
-            self.next_token();
-        }
-
-        let cur_token = self.cur_token.borrow().clone();
-
-        if *cur_token.token_type() == TokenType::Literal
-            || *cur_token.token_type() == TokenType::Num
-        {
-            let value = cur_token.literal().to_string();
-            self.next_token();
-
-            return Some(value);
-        }
-
-        None
     }
 
     // Update the current token and move the position that in Lexer to next token.

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -248,10 +248,8 @@ impl Parser {
 
     // Parse the matching rules of the 'Pattern matching' command.
     fn parse_pattern(&self) -> Option<String> {
-        let cur_token = self.cur_token.borrow().clone();
-
         // If the current token is a double quotation mark, then the pattern is complete.
-        if *cur_token.token_type() == TokenType::Quote {
+        if *self.cur_token.borrow().token_type() == TokenType::Quote {
             self.next_token();
         } else {
             self.collect_error("Missing pattern. You can use `\"` to quote the pattern.");
@@ -262,13 +260,13 @@ impl Parser {
         // until the condition is not met.
         let mut pattern = String::from("");
         loop {
-            if *cur_token.token_type() == TokenType::Literal
-                || *cur_token.token_type() == TokenType::Num
-                || *cur_token.token_type() == TokenType::Slash
-                || *cur_token.token_type() == TokenType::Dot
-                || *cur_token.token_type() == TokenType::Tilde
+            if *self.cur_token.borrow().token_type() == TokenType::Literal
+                || *self.cur_token.borrow().token_type() == TokenType::Num
+                || *self.cur_token.borrow().token_type() == TokenType::Slash
+                || *self.cur_token.borrow().token_type() == TokenType::Dot
+                || *self.cur_token.borrow().token_type() == TokenType::Tilde
             {
-                pattern.push_str(cur_token.literal());
+                pattern.push_str(self.cur_token.borrow().literal());
                 self.next_token();
             } else {
                 break;
@@ -276,7 +274,7 @@ impl Parser {
         }
 
         // If the current token is a double quotation mark, then the pattern is complete.
-        if *cur_token.token_type() == TokenType::Quote {
+        if *self.cur_token.borrow().token_type() == TokenType::Quote {
             self.next_token();
         } else {
             self.collect_error("Invalid pattern, missing right quotation mark.");
@@ -292,7 +290,7 @@ impl Parser {
 
         loop {
             let cur_token = self.cur_token.borrow().clone();
-            match cur_token.token_type() {
+            match *cur_token.token_type() {
                 TokenType::Tilde
                 | TokenType::Literal
                 | TokenType::Num
@@ -321,9 +319,7 @@ impl Parser {
 
     // Parse the path of the command.
     fn parse_path(&self) -> Option<String> {
-        let cur_token = self.cur_token.borrow().clone();
-
-        let mut path = String::from(cur_token.literal());
+        let mut path = String::from(self.cur_token.borrow().literal());
         self.next_token();
 
         loop {
@@ -331,13 +327,13 @@ impl Parser {
                 break;
             }
 
-            if *cur_token.token_type() == TokenType::Literal
-                || *cur_token.token_type() == TokenType::Num
-                || *cur_token.token_type() == TokenType::Slash
-                || *cur_token.token_type() == TokenType::Dot
-                || *cur_token.token_type() == TokenType::Tilde
+            if *self.cur_token.borrow().token_type() == TokenType::Literal
+                || *self.cur_token.borrow().token_type() == TokenType::Num
+                || *self.cur_token.borrow().token_type() == TokenType::Slash
+                || *self.cur_token.borrow().token_type() == TokenType::Dot
+                || *self.cur_token.borrow().token_type() == TokenType::Tilde
             {
-                path.push_str(cur_token.literal());
+                path.push_str(self.cur_token.borrow().literal());
                 self.next_token();
             } else {
                 break;

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -30,7 +30,7 @@ pub struct Parser {
     lexer: Lexer,
 
     // The current token that the parser is looking at.
-    cur_token: RefCell<Option<Token>>,
+    cur_token: RefCell<Token>,
 
     // Use to get command and its parameter from lexer.
     cmd_start_index: Cell<u32>,
@@ -73,7 +73,7 @@ impl Parser {
         let parser = Parser {
             lexer: Lexer::new(input),
             command_ast: RefCell::new(Vec::new()),
-            cur_token: RefCell::new(None),
+            cur_token: RefCell::new(Token::new(TokenType::Eof, "")),
             cmd_start_index: Cell::new(0),
             cmd_end_index: Cell::new(0),
             errors: Rc::new(RefCell::new(Vec::new())),
@@ -101,15 +101,11 @@ impl Parser {
 
     // Parse the command and return the AST.
     fn parse(&self) {
-        if self.cur_token.borrow().is_none() {
-            return;
-        }
-
-        if self.cur_token.borrow().clone().unwrap().token_type() == &TokenType::Eof {
-            return;
-        }
-
         loop {
+            if self.cur_token.borrow().clone().token_type() == &TokenType::Eof {
+                return;
+            }
+            
             // Check if the current token is a command.
             if !self.check_wether_is_command() {
                 self.collect_error("Invalid command");
@@ -151,15 +147,11 @@ impl Parser {
     // Check if the current token is a command.
     fn check_wether_is_command(&self) -> bool {
         let cur_token = self.cur_token.borrow().clone();
-        match cur_token {
-            Some(ref token) => match token.token_type() {
-                TokenType::Ls | TokenType::Cd | TokenType::Grep | TokenType::Cat => true,
-                // This means the end of the command.
-                TokenType::Eof => true,
-                _ => false,
-            },
-            // This is equivalent to TokenType::Eof.
-            None => true,
+        match cur_token.token_type() {
+            TokenType::Ls | TokenType::Cd | TokenType::Grep | TokenType::Cat => true,
+            // This means the end of the command.
+            TokenType::Eof => false,
+            _ => false,
         }
     }
 
@@ -173,14 +165,11 @@ impl Parser {
         let cur_token = self.cur_token.borrow().clone();
         // Parse the corresponding command based on the token type
         // and return the parsed AST (Abstract Syntax Tree) node.
-        let ext_cmd: Option<Box<dyn CommandAstNode>> = match cur_token {
-            Some(ref token) => match token.token_type() {
-                TokenType::Ls | TokenType::Cd | TokenType::Grep | TokenType::Cat => {
-                    Some(self.parse_exe_command())
-                }
-                _ => None,
-            },
-            None => None,
+        let ext_cmd: Option<Box<dyn CommandAstNode>> = match cur_token.token_type() {
+            TokenType::Ls | TokenType::Cd | TokenType::Grep | TokenType::Cat => {
+                Some(self.parse_exe_command())
+            }
+            _ => None,
         };
 
         ext_cmd
@@ -189,7 +178,7 @@ impl Parser {
     // Parse the command whose type is chain command.
     fn parse_chain_cmd(&self) -> Option<Box<dyn CommandAstNode>> {
         if self.is_chain_token() {
-            let cur_token = self.cur_token.borrow().clone().unwrap();
+            let cur_token = self.cur_token.borrow().clone();
             let mut cmd = ChainCommandAstNode::new(cur_token);
 
             // Move to next Token to parse
@@ -206,26 +195,16 @@ impl Parser {
 
     // Judge current token if is chain token.
     fn is_chain_token(&self) -> bool {
-        match self.cur_token.borrow().clone() {
-            Some(token) => {
-                if token.token_type() == &TokenType::Pipe {
-                    return true;
-                }
-                false
-            }
-            None => false,
+        if self.cur_token.borrow().token_type() == &TokenType::Pipe {
+            return true;
         }
+        false
     }
 
     // Parse execute command
     fn parse_exe_command(&self) -> Box<dyn CommandAstNode> {
-        let cur_token = self.cur_token.borrow().clone();
-
         // Build the exe command node.
-        let mut exe_command = match cur_token {
-            Some(token) => ExeCommandAstNode::new(token),
-            None => panic!("No token"),
-        };
+        let mut exe_command = ExeCommandAstNode::new(self.cur_token.borrow().clone());
 
         self.next_token();
 
@@ -261,26 +240,19 @@ impl Parser {
         match self.parse_chain_cmd() {
             Some(mut token) => {
                 token.set_source(Some(Box::new(exe_command)));
-                return token;
+                token
             }
-            None => return Box::new(exe_command),
+            None => Box::new(exe_command),
         }
     }
 
     // Parse the matching rules of the 'Pattern matching' command.
     fn parse_pattern(&self) -> Option<String> {
-        let mut cur_token = match self.cur_token.borrow().clone() {
-            Some(token) => token,
-            None => return None,
-        };
+        let cur_token = self.cur_token.borrow().clone();
 
         // If the current token is a double quotation mark, then the pattern is complete.
         if *cur_token.token_type() == TokenType::Quote {
             self.next_token();
-            cur_token = match self.cur_token.borrow().clone() {
-                Some(token) => token,
-                None => return None,
-            };
         } else {
             self.collect_error("Missing pattern. You can use `\"` to quote the pattern.");
             return None;
@@ -298,10 +270,6 @@ impl Parser {
             {
                 pattern.push_str(cur_token.literal());
                 self.next_token();
-                cur_token = match self.cur_token.borrow().clone() {
-                    Some(token) => token,
-                    None => return None,
-                };
             } else {
                 break;
             }
@@ -324,25 +292,20 @@ impl Parser {
 
         loop {
             let cur_token = self.cur_token.borrow().clone();
-            match cur_token {
-                Some(ref token) => match token.token_type() {
-                    TokenType::Tilde
-                    | TokenType::Literal
-                    | TokenType::Num
-                    | TokenType::Slash
-                    | TokenType::Dot => {
-                        paths.push(self.parse_path().unwrap());
-                    }
-                    _ => break,
-                },
-                None => break,
-            }
+            match cur_token.token_type() {
+                TokenType::Tilde
+                | TokenType::Literal
+                | TokenType::Num
+                | TokenType::Slash
+                | TokenType::Dot => {
+                    paths.push(self.parse_path().unwrap());
+                }
+                _ => break,
+            };
 
             // Skip the comma and get next path.
             // If the current token isn't comma, then break the loop.
-            if self.cur_token.borrow().is_none()
-                || self.cur_token.borrow().clone().unwrap().token_type() != &TokenType::Comma
-            {
+            if self.cur_token.borrow().clone().token_type() != &TokenType::Comma {
                 break;
             } else {
                 self.next_token();
@@ -358,27 +321,23 @@ impl Parser {
 
     // Parse the path of the command.
     fn parse_path(&self) -> Option<String> {
-        let cur_token = match self.cur_token.borrow().clone() {
-            Some(token) => token,
-            None => return None,
-        };
+        let cur_token = self.cur_token.borrow().clone();
 
         let mut path = String::from(cur_token.literal());
         self.next_token();
 
         loop {
-            let token = match self.cur_token.borrow().clone() {
-                Some(token) => token,
-                None => return Some(path),
-            };
+            if self.lexer.peek_token().is_none() {
+                break;
+            }
 
-            if *token.token_type() == TokenType::Literal
-                || *token.token_type() == TokenType::Num
-                || *token.token_type() == TokenType::Slash
-                || *token.token_type() == TokenType::Dot
-                || *token.token_type() == TokenType::Tilde
+            if *cur_token.token_type() == TokenType::Literal
+                || *cur_token.token_type() == TokenType::Num
+                || *cur_token.token_type() == TokenType::Slash
+                || *cur_token.token_type() == TokenType::Dot
+                || *cur_token.token_type() == TokenType::Tilde
             {
-                path.push_str(token.literal());
+                path.push_str(cur_token.literal());
                 self.next_token();
             } else {
                 break;
@@ -395,20 +354,17 @@ impl Parser {
         loop {
             // If the current token isn't a parameter, then break the loop.
             let cur_token = self.cur_token.borrow().clone();
-            match cur_token {
-                Some(ref token) => match token.token_type() {
-                    TokenType::ShortParam | TokenType::LongParam => {
-                        match self.parse_option() {
-                            Some((param, value)) => {
-                                params.push((param, value));
-                            }
-                            None => break,
-                        };
-                    }
-                    _ => break,
-                },
-                None => break,
-            }
+            match cur_token.token_type() {
+                TokenType::ShortParam | TokenType::LongParam => {
+                    match self.parse_option() {
+                        Some((param, value)) => {
+                            params.push((param, value));
+                        }
+                        None => break,
+                    };
+                }
+                _ => break,
+            };
         }
 
         Some(params)
@@ -416,10 +372,7 @@ impl Parser {
 
     // Parse the parameters of the command.
     fn parse_option(&self) -> Option<(String, String)> {
-        let cur_token = match self.cur_token.borrow().clone() {
-            Some(token) => token,
-            None => return None,
-        };
+        let cur_token = self.cur_token.borrow().clone();
 
         // Get the parameter and its value.
         if *cur_token.token_type() == TokenType::ShortParam
@@ -445,20 +398,14 @@ impl Parser {
     // 3. ls --color=auto       : the value 'auto' is assigned to the '--color' parameter with '='.
     // So it is necessary to check in what way the value is assigned to the parameter.
     fn parse_param_value(&self) -> Option<String> {
-        let cur_token = match self.cur_token.borrow().clone() {
-            Some(token) => token,
-            None => return None,
-        };
+        let cur_token = self.cur_token.borrow().clone();
 
         // Skip the assignment operator.
         if *cur_token.token_type() == TokenType::Assignment {
             self.next_token();
         }
 
-        let cur_token = match self.cur_token.borrow().clone() {
-            Some(token) => token,
-            None => return None,
-        };
+        let cur_token = self.cur_token.borrow().clone();
 
         if *cur_token.token_type() == TokenType::Literal
             || *cur_token.token_type() == TokenType::Num
@@ -478,8 +425,8 @@ impl Parser {
         let mut cur_token = self.cur_token.borrow_mut();
 
         match token {
-            Some(t) => *cur_token = Some(t),
-            None => *cur_token = None,
+            Some(t) => *cur_token = t,
+            None => *cur_token = Token::new(TokenType::Eof, ""),
         }
 
         let end_index = self.cmd_end_index.get();

--- a/src/parser/parsing_func.rs
+++ b/src/parser/parsing_func.rs
@@ -1,0 +1,262 @@
+use crate::token::token::TokenType;
+
+use super::{ast_node_trait::CommandAstNode, cmds_ast_node::ExeCommandAstNode, Parser};
+
+// Here are the parsing functions for parsing each command type
+// Due to the different nature of each command, they are separated into different functions
+impl Parser {
+    // Parse the ls command.
+    // The ls command has the following options:
+    // -l, --long: show the long format
+    // -a, --all: do not ignore entries starting with .
+    // -h, --human-readable: with -l and/or -s, print human readable sizes
+    // -r, --reverse: reverse order while sorting
+    // -t, --time: sort by modification time, newest first
+    // -s, --size: sort by file size, largest first
+    // --tree: show the directory tree
+    // --depth: show the directory tree with the specified depth
+    pub fn parse_ls_cmd(&self) -> Option<Box<dyn CommandAstNode>> {
+        // Build the exe command node.
+        let mut ls_cmd = ExeCommandAstNode::new(self.cur_token.borrow().clone());
+
+        self.next_token();
+
+        // Parse the parameters of the command.
+        let mut options: Vec<(String, String)> = Vec::new();
+        loop {
+            if *self.cur_token.borrow().token_type() == TokenType::Eof
+                || !(*self.cur_token.borrow().token_type() == TokenType::ShortParam
+                    || *self.cur_token.borrow().token_type() == TokenType::LongParam)
+            {
+                break;
+            }
+
+            let cur_token = self.cur_token.borrow().clone();
+            match cur_token.literal() {
+                "-l" | "--long" => {
+                    options.push(self.parse_option(false));
+                }
+                "-a" | "--all" => {
+                    options.push(self.parse_option(false));
+                }
+                "-h" | "--human-readable" => {
+                    options.push(self.parse_option(false));
+                }
+                "-r" | "--reverse" => {
+                    options.push(self.parse_option(false));
+                }
+                "-t" | "--time" => {
+                    options.push(self.parse_option(false));
+                }
+                "-s" | "--size" => {
+                    options.push(self.parse_option(false));
+                }
+                "--tree" => {
+                    options.push(self.parse_option(false));
+                }
+                "--depth" => {
+                    options.push(self.parse_option(true));
+                }
+                _ => {
+                    options.push(self.parse_option(false));
+                }
+            }
+        }
+        ls_cmd.set_options(options);
+
+        // Parse the paths of the ls command.
+        match self.parse_paths() {
+            Some(paths) => ls_cmd.set_values(paths),
+            None => (),
+        };
+
+        Some(Box::new(ls_cmd))
+    }
+
+    // Parse the grep command.
+    // The grep command has the following options:
+    // -i, --ignore-case: ignore case distinctions
+    // -v, --invert-match: select non-matching lines
+    // -c, --count: print only a count of matching lines per FILE
+    // -n, --line-number: print line number with output lines
+    pub fn parse_grep_cmd(&self) -> Option<Box<dyn CommandAstNode>> {
+        // Build the exe command node.
+        let mut grep_cmd: ExeCommandAstNode =
+            ExeCommandAstNode::new(self.cur_token.borrow().clone());
+
+        self.next_token();
+
+        // Parse the parameters of the command.
+        let mut options: Vec<(String, String)> = Vec::new();
+        loop {
+            if *self.cur_token.borrow().token_type() == TokenType::Eof
+                || !(*self.cur_token.borrow().token_type() == TokenType::ShortParam
+                    || *self.cur_token.borrow().token_type() == TokenType::LongParam)
+            {
+                break;
+            }
+
+            let cur_token = self.cur_token.borrow().clone();
+            match cur_token.literal() {
+                "-i" | "--ignore-case" => {
+                    options.push(self.parse_option(false));
+                }
+                "-v" | "--invert-match" => {
+                    options.push(self.parse_option(false));
+                }
+                "-c" | "--count" => {
+                    options.push(self.parse_option(false));
+                }
+                "-n" | "--line-number" => {
+                    options.push(self.parse_option(false));
+                }
+                _ => {
+                    options.push(self.parse_option(false));
+                }
+            }
+        }
+        grep_cmd.set_options(options);
+
+        // set the pattern of the grep command.
+        let pattern = match self.parse_pattern() {
+            Some(pattern) => pattern,
+            None => return None,
+        };
+        grep_cmd.add_value(pattern);
+
+        // Parse the paths of the ls command.
+        match self.parse_paths() {
+            Some(paths) => grep_cmd.set_values(paths),
+            None => {
+                self.collect_error("Grep command needs a path");
+            }
+        };
+
+        Some(Box::new(grep_cmd))
+    }
+
+    pub fn parse_cat_cmd(&self) -> Option<Box<dyn CommandAstNode>> {
+        todo!()
+    }
+
+    // Parse the parameters of the command.
+    // @param whether_parsing_value: whether the parser is parsing the value of the option.
+    pub fn parse_option(&self, whether_parsing_value: bool) -> (String, String) {
+        let option = self.cur_token.borrow().literal().to_string();
+        self.next_token();
+
+        // Parse the value of the option.
+        let mut value = String::from("");
+        if whether_parsing_value {
+            // Skip the assignment operator.
+            if *self.cur_token.borrow().token_type() == TokenType::Assignment {
+                self.next_token();
+            }
+
+            if *self.cur_token.borrow().token_type() == TokenType::Literal
+                || *self.cur_token.borrow().token_type() == TokenType::Num
+            {
+                value = self.cur_token.borrow().literal().to_string();
+                self.next_token();
+            }
+        }
+
+        (option, value)
+    }
+
+    // Parse the paths of the command.
+    pub fn parse_paths(&self) -> Option<Vec<String>> {
+        let mut paths: Vec<String> = Vec::new();
+
+        loop {
+            let cur_tok = self.cur_token.borrow().clone();
+            match *cur_tok.token_type() {
+                TokenType::Tilde
+                | TokenType::Literal
+                | TokenType::Num
+                | TokenType::Slash
+                | TokenType::Dot => {
+                    paths.push(self.parse_path().unwrap());
+                }
+                _ => break,
+            };
+
+            // Skip the comma and get next path.
+            // If the current token isn't comma, then break the loop.
+            if self.cur_token.borrow().clone().token_type() != &TokenType::Comma {
+                break;
+            }
+            self.next_token();
+        }
+
+        if paths.is_empty() {
+            None
+        } else {
+            Some(paths)
+        }
+    }
+
+    // Parse the path of the command.
+    fn parse_path(&self) -> Option<String> {
+        let mut path = String::from(self.cur_token.borrow().literal());
+        self.next_token();
+
+        loop {
+            if self.lexer.peek_token().is_none() {
+                break;
+            }
+
+            if *self.cur_token.borrow().token_type() == TokenType::Literal
+                || *self.cur_token.borrow().token_type() == TokenType::Num
+                || *self.cur_token.borrow().token_type() == TokenType::Slash
+                || *self.cur_token.borrow().token_type() == TokenType::Dot
+                || *self.cur_token.borrow().token_type() == TokenType::Tilde
+            {
+                path.push_str(self.cur_token.borrow().literal());
+                self.next_token();
+            } else {
+                break;
+            }
+        }
+
+        Some(path)
+    }
+
+    // Parse the matching rules of the 'Pattern matching' command.
+    fn parse_pattern(&self) -> Option<String> {
+        // If the current token is a double quotation mark, then the pattern is complete.
+        if *self.cur_token.borrow().token_type() == TokenType::Quote {
+            self.next_token();
+        } else {
+            self.collect_error("Missing pattern. You can use `\"` to quote the pattern.");
+            return None;
+        }
+
+        // Iterate through the subsequent tokens and add them to the current pattern
+        // until the condition is not met.
+        let mut pattern = String::from("");
+        loop {
+            if *self.cur_token.borrow().token_type() == TokenType::Literal
+                || *self.cur_token.borrow().token_type() == TokenType::Num
+                || *self.cur_token.borrow().token_type() == TokenType::Slash
+                || *self.cur_token.borrow().token_type() == TokenType::Dot
+                || *self.cur_token.borrow().token_type() == TokenType::Tilde
+            {
+                pattern.push_str(self.cur_token.borrow().literal());
+                self.next_token();
+            } else {
+                break;
+            }
+        }
+
+        // If the current token is a double quotation mark, then the pattern is complete.
+        if *self.cur_token.borrow().token_type() == TokenType::Quote {
+            self.next_token();
+        } else {
+            self.collect_error("Invalid pattern, missing right quotation mark.");
+            return None;
+        }
+
+        Some(pattern)
+    }
+}

--- a/tests/parser_test.rs
+++ b/tests/parser_test.rs
@@ -9,7 +9,7 @@ mod parser_test {
     fn test_show_command() {
         let mut command_ast: Vec<Box<dyn CommandAstNode>> = Vec::new();
 
-        let mut ls_command = ExeCommandAstNode::new(Token::new(TokenType::Ls, "ls".to_string()));
+        let mut ls_command = ExeCommandAstNode::new(Token::new(TokenType::Ls, "ls"));
         ls_command.set_options(vec![
             ("-l".to_string(), "".to_string()),
             ("-h".to_string(), "".to_string()),
@@ -19,8 +19,6 @@ mod parser_test {
         ls_command.set_values(vec!["Programs/Rust/ru-shell".to_string()]);
 
         command_ast.push(Box::new(ls_command));
-
-        // println!("{:#?}", command_ast);
     }
 
     #[test]

--- a/tests/parser_test.rs
+++ b/tests/parser_test.rs
@@ -77,8 +77,6 @@ mod parser_test {
     fn test_grep_command_parse() {
         let parser = Parser::new("grep -i -n -r \"main\" ~/Programs/Rust/ru-shell");
 
-        // println!("{:#?}", parser);
-
         let cmd = parser.iter().next().unwrap();
         assert_eq!(cmd.cmd_type(), &CommandType::ExtCommand);
         assert_eq!(cmd.token_type(), &TokenType::Grep);


### PR DESCRIPTION
- Refactor the syntax parser, writing independent parsing logic for each command, ensuring that each command parses its own options and their corresponding values.
- Modify the type of 'cur_token' field in 'Parser' from 'RefCell<Option<Token>>' to 'RefCell<Token>', and pass the test
- Add the long option names for 'grep' command.
- Rename the 'resort' field to 'reverse' in 'LsCmd'.